### PR TITLE
Verify returned KeyId in AwsAead.Decrypt (Java parity)

### DIFF
--- a/integration/awskms/aws_kms_aead.go
+++ b/integration/awskms/aws_kms_aead.go
@@ -19,6 +19,8 @@ package awskms
 
 import (
 	"encoding/hex"
+	"fmt"
+	"strings"
 
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/service/kms"
@@ -80,5 +82,21 @@ func (a *AWSAEAD) Decrypt(ciphertext, associatedData []byte) ([]byte, error) {
 	if err != nil {
 		return nil, err
 	}
+	// Verify the returned KeyId matches the configured one. If we don't do this,
+	// the possibility exists for the ciphertext to be replaced by one under a key
+	// we don't control/expect, but do have decrypt permissions on. The check is
+	// disabled if keyID is not in key ARN format, matching the behavior of the
+	// Java SDK (AwsKmsAead.java:92).
+	// See https://docs.aws.amazon.com/kms/latest/developerguide/concepts.html#key-id.
+	if isKeyArnFormat(a.keyID) && resp.KeyId != nil && *resp.KeyId != a.keyID {
+		return nil, fmt.Errorf("decryption failed: wrong key id")
+	}
 	return resp.Plaintext, nil
+}
+
+// isKeyArnFormat reports whether keyID is in key ARN format
+// (arn:<partition>:kms:<region>:<account>:key/<key-id>).
+func isKeyArnFormat(keyID string) bool {
+	parts := strings.Split(keyID, ":")
+	return len(parts) == 6 && strings.HasPrefix(parts[5], "key/")
 }

--- a/integration/awskms/aws_kms_aead_test.go
+++ b/integration/awskms/aws_kms_aead_test.go
@@ -1,0 +1,116 @@
+// Copyright 2026 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package awskms
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/service/kms"
+	"github.com/aws/aws-sdk-go/service/kms/kmsiface"
+)
+
+// keySwappingKMS is a fake KMS API that returns a configurable KeyId in the
+// Decrypt response, simulating a server that decrypts under a different key
+// than the one specified in the request. Used to verify that the client-side
+// KeyId mismatch check rejects such ciphertexts.
+type keySwappingKMS struct {
+	kmsiface.KMSAPI
+	returnedKeyID string
+}
+
+func (k *keySwappingKMS) Decrypt(req *kms.DecryptInput) (*kms.DecryptOutput, error) {
+	return &kms.DecryptOutput{
+		Plaintext: []byte("plaintext"),
+		KeyId:     aws.String(k.returnedKeyID),
+	}, nil
+}
+
+func TestDecryptRejectsWrongKeyId(t *testing.T) {
+	configuredKeyARN := "arn:aws:kms:us-east-2:235739564943:key/3ee50705-5a82-4f5b-9753-05c4f473922f"
+	otherKeyARN := "arn:aws:kms:us-east-2:235739564943:key/00000000-0000-0000-0000-000000000000"
+	fakeKMS := &keySwappingKMS{returnedKeyID: otherKeyARN}
+
+	a := newAWSAEAD(configuredKeyARN, fakeKMS, AssociatedData)
+	_, err := a.Decrypt([]byte("ciphertext"), []byte("ad"))
+	if err == nil {
+		t.Fatalf("a.Decrypt() err = nil, want error (KeyId mismatch should be rejected)")
+	}
+	if !strings.Contains(err.Error(), "wrong key id") {
+		t.Errorf("a.Decrypt() err = %v, want error containing 'wrong key id'", err)
+	}
+}
+
+func TestDecryptAcceptsMatchingKeyId(t *testing.T) {
+	keyARN := "arn:aws:kms:us-east-2:235739564943:key/3ee50705-5a82-4f5b-9753-05c4f473922f"
+	fakeKMS := &keySwappingKMS{returnedKeyID: keyARN}
+
+	a := newAWSAEAD(keyARN, fakeKMS, AssociatedData)
+	plaintext, err := a.Decrypt([]byte("ciphertext"), []byte("ad"))
+	if err != nil {
+		t.Fatalf("a.Decrypt() err = %v, want nil", err)
+	}
+	if string(plaintext) != "plaintext" {
+		t.Errorf("a.Decrypt() = %q, want %q", plaintext, "plaintext")
+	}
+}
+
+func TestDecryptSkipsCheckForNonArnKeyID(t *testing.T) {
+	// Tink-Java disables the KeyId check when the configured key is not in key
+	// ARN format (e.g. plain key id, alias/<name>, or alias ARN). This matches
+	// that behavior — non-ARN ids are accepted regardless of the returned KeyId.
+	tests := []struct {
+		name string
+		id   string
+	}{
+		{"plain key id", "3ee50705-5a82-4f5b-9753-05c4f473922f"},
+		{"alias name", "alias/test-alias"},
+		{"alias ARN (5 segments)", "arn:aws:kms:us-east-2:235739564943:alias/test-alias"},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			fakeKMS := &keySwappingKMS{
+				returnedKeyID: "arn:aws:kms:us-east-2:235739564943:key/different-key",
+			}
+			a := newAWSAEAD(test.id, fakeKMS, AssociatedData)
+			if _, err := a.Decrypt([]byte("ciphertext"), []byte("ad")); err != nil {
+				t.Errorf("a.Decrypt() err = %v, want nil (non-ARN id should skip check)", err)
+			}
+		})
+	}
+}
+
+func TestIsKeyArnFormat(t *testing.T) {
+	tests := []struct {
+		name  string
+		id    string
+		isArn bool
+	}{
+		{"valid key ARN", "arn:aws:kms:us-east-2:235739564943:key/3ee50705-5a82-4f5b-9753-05c4f473922f", true},
+		{"valid GovCloud key ARN", "arn:aws-us-gov:kms:us-gov-east-1:235739564943:key/3ee50705-5a82-4f5b-9753-05c4f473922f", true},
+		{"alias ARN", "arn:aws:kms:us-east-2:235739564943:alias/my-alias", false},
+		{"plain key id", "3ee50705-5a82-4f5b-9753-05c4f473922f", false},
+		{"alias name", "alias/my-alias", false},
+		{"empty", "", false},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			if got := isKeyArnFormat(test.id); got != test.isArn {
+				t.Errorf("isKeyArnFormat(%q) = %v, want %v", test.id, got, test.isArn)
+			}
+		})
+	}
+}


### PR DESCRIPTION
## Summary
Tink-Java's `AwsKmsAead.decrypt` (AwsKmsAead.java:92) explicitly rejects ciphertexts where the AWS KMS response's `KeyId` does not match the configured key ARN, with this security comment:

> *"It is important to check the returned KeyId against the one previously configured. If we don't do this, the possibility exists for the ciphertext to be replaced by one under a key we don't control/expect, but do have decrypt permissions on."*

The Go port is missing the same defense. This PR brings it to parity.

## Threat model (per Java comment)
A caller with `kms:Decrypt` permission on more than one KMS key (target key + attacker-controlled key) can be tricked into decrypting an attacker-supplied ciphertext under the attacker's key, while the application believed it was decrypting under its configured key. The application then uses the resulting plaintext as if the original ciphertext owner had blessed it.

AWS server-side enforcement isn't always sufficient by itself — Tink-Java explicitly added the client-side check anyway, with a documented rationale.

## Behavior
- When `keyID` is in **key ARN format** (`arn:<partition>:kms:<region>:<account>:key/<id>`) and the response's `KeyId` differs, `Decrypt` returns `decryption failed: wrong key id`.
- When `keyID` is **not** in key ARN format (plain key id, `alias/<name>`, or alias ARN), the check is skipped — matching Java's behavior to avoid false rejections for callers that use aliases.

## Tests
New `aws_kms_aead_test.go`:
- `TestDecryptRejectsWrongKeyId` — configured ARN ≠ returned ARN, expects rejection
- `TestDecryptAcceptsMatchingKeyId` — happy path
- `TestDecryptSkipsCheckForNonArnKeyID` — plain key id / alias / alias ARN must not trigger the check
- `TestIsKeyArnFormat` — ARN-shape unit test

## Sibling work
The same gap exists in `tink-cc-awskms` (`aws_kms_aead.cc:91-115`) and will be filed in a follow-up PR there once this lands.

## Reference
- Java implementation: `tink-java-awskms` `AwsKmsAead.java:92` — `if (isKeyArnFormat(keyArn) && !result.keyId().equals(keyArn))`
- AWS KMS Decrypt API returns `KeyId` in response: https://docs.aws.amazon.com/kms/latest/APIReference/API_Decrypt.html